### PR TITLE
feat: add DB persistence with SQLAlchemy + Alembic scaffold

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,36 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+from alembic import context
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.db import engine
+from src.models import Base
+
+# this is the Alembic Config object, which provides access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    context.configure(url=str(engine.url), target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,18 @@
+# Database migrations
+
+This project uses SQLAlchemy for models and Alembic for migrations.
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Initialize and run migrations (example):
+
+```bash
+alembic revision --autogenerate -m "create activities and participants"
+alembic upgrade head
+```
+
+By default the app uses SQLite at `./activities.db`. You can set `DATABASE_URL` to a Postgres or other DB URL.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlalchemy
+alembic

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,16 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
 import os
 from pathlib import Path
+
+from .db import engine, Base, get_db
+from .models import Activity, Participant
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +24,12 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+@app.on_event("startup")
+def startup():
+    # Create tables if they don't exist
+    Base.metadata.create_all(bind=engine)
+
 
 
 @app.get("/")
@@ -84,49 +38,48 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
+def get_activities(db: Session = Depends(get_db)):
+    # Return activities with participant emails
+    activities = {}
+    for activity in db.query(Activity).all():
+        parts = [p.email for p in db.query(Participant).filter(Participant.activity_id == activity.id).all()]
+        activities[activity.name] = {
+            "description": activity.description,
+            "schedule": activity.schedule,
+            "max_participants": activity.max_participants,
+            "participants": parts,
+        }
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    existing = db.query(Participant).filter(Participant.activity_id == activity.id, Participant.email == email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
+    # add participant
+    participant = Participant(email=email, activity_id=activity.id)
+    db.add(participant)
+    db.commit()
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+def unregister_from_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    participant = db.query(Participant).filter(Participant.activity_id == activity.id, Participant.email == email).first()
+    if not participant:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
+    db.delete(participant)
+    db.commit()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./activities.db")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if "sqlite" in DATABASE_URL else {})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String, Table, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    description = Column(String, default="")
+    schedule = Column(String, default="")
+    max_participants = Column(Integer, default=0)
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=False)
+


### PR DESCRIPTION
This PR adds initial database persistence for activities and participants using SQLAlchemy and provides a minimal Alembic env scaffold for migrations.

Changes:
- Add `src/db.py` with SQLAlchemy engine, session, and Base.
- Add `src/models.py` with `Activity` and `Participant` models.
- Update `src/app.py` to create tables at startup and use DB-backed endpoints for `/activities`, signup, and unregister.
- Add `alembic/env.py` migration environment and `docs/MIGRATIONS.md` with basic instructions.
- Update `requirements.txt` to include `sqlalchemy` and `alembic`.

Notes:
- The runtime environment in this container doesn't have dependencies installed, so I didn't run migrations locally. To run migrations:
  1. pip install -r requirements.txt
  2. alembic revision --autogenerate -m "create activities and participants"
  3. alembic upgrade head

Next steps I recommend (I can do these):
- Add an initial Alembic revision file (I can autogenerate one in a follow-up PR).
- Add seed data for activities (a lightweight script or migration).
- Add tests for DB-backed endpoints.
